### PR TITLE
Add setup pages

### DIFF
--- a/src/admin/Connect/Connector.php
+++ b/src/admin/Connect/Connector.php
@@ -31,8 +31,6 @@ class Connector
             return null;
         }
 
-        self::setupPages();
-
         Helper::setConfig('key', $integration_key['id']);
         Helper::setConfig('card', $integration_key['card']['id']);
         Helper::setConfig('secret', $integration_key['secret']);

--- a/src/admin/Connect/Connector.php
+++ b/src/admin/Connect/Connector.php
@@ -13,6 +13,7 @@ class Connector
         if (Helper::isSetup()) {
             add_action('admin_init', array(__CLASS__, 'registerSettingOptions'));
         }
+        add_action('admin_init', array(__CLASS__, 'setupPages'));
     }
 
     public static function processSetup()
@@ -91,5 +92,11 @@ class Connector
         <label for="beans-liana-display-redemption-checkout">Display redemption on checkout page</label>
       </div>
         <?php
+    }
+
+    public static function setupPages()
+    {
+        self::installAssets('liana');
+        self::installAssets('bamboo');
     }
 }

--- a/src/admin/Connect/Connector.php
+++ b/src/admin/Connect/Connector.php
@@ -13,7 +13,6 @@ class Connector
         if (Helper::isSetup()) {
             add_action('admin_init', array(__CLASS__, 'registerSettingOptions'));
         }
-        self::setupPages();
     }
 
     public static function processSetup()
@@ -51,7 +50,6 @@ class Connector
         $page_infos = Helper::getBeansPages()[$name];
 
         if (!get_post(Helper::getConfig($name . '_page'))) {
-            require_once(WP_PLUGIN_DIR . '/woocommerce/includes/admin/wc-admin-functions.php');
             $page_id = wc_create_page(
                 $page_infos['slug'],
                 $page_infos['option'],

--- a/src/admin/Connect/Connector.php
+++ b/src/admin/Connect/Connector.php
@@ -13,7 +13,7 @@ class Connector
         if (Helper::isSetup()) {
             add_action('admin_init', array(__CLASS__, 'registerSettingOptions'));
         }
-        add_action('admin_init', array(__CLASS__, 'setupPages'));
+        self::setupPages();
     }
 
     public static function processSetup()
@@ -32,8 +32,7 @@ class Connector
             return null;
         }
 
-        self::installAssets('liana');
-        self::installAssets('bamboo');
+        self::setupPages();
 
         Helper::setConfig('key', $integration_key['id']);
         Helper::setConfig('card', $integration_key['card']['id']);
@@ -52,6 +51,7 @@ class Connector
         $page_infos = Helper::getBeansPages()[$name];
 
         if (!get_post(Helper::getConfig($name . '_page'))) {
+            require_once(WP_PLUGIN_DIR . '/woocommerce/includes/admin/wc-admin-functions.php');
             $page_id = wc_create_page(
                 $page_infos['slug'],
                 $page_infos['option'],

--- a/src/admin/Connect/connector-connect.html.php
+++ b/src/admin/Connect/connector-connect.html.php
@@ -5,8 +5,10 @@ defined('ABSPATH') or die;
 use BeansWoo\Helper;
 use BeansWoo\Admin\Router;
 use BeansWoo\Admin\Inspector;
+use BeansWoo\Admin\Connector;
 
 Inspector::init();
+Connector::setupPages();
 $base_banner_url = 'https://' . Helper::getDomain('CDN') . '/static-v3/connect/img/app/';
 $base_asset_url  = Helper::getAssetURL('/assets/img/admin');
 


### PR DESCRIPTION
During our refactoring, we removed this behavior of our plugin. 
We have to create the page when the plugin is just activated to avoid bad redirecting.