### PR TITLE
Fix commit redemption method

### DIFF
--- a/src/storefront/liana/Observer/LianaObserver.php
+++ b/src/storefront/liana/Observer/LianaObserver.php
@@ -82,7 +82,7 @@ class LianaObserver
 
                 $data = array(
                     'quantity'    => $amount,
-                    'rule'        => strtoupper(get_woocommerce_currency()),
+                    'rule'        => strtoupper(get_option('woocommerce_currency')),
                     'account'     => $account_id,
                     'description' => "Debited for a $amount_str discount on order #" . $order->get_id(),
                     'uid'         => 'wc_' . $order->get_id() . '_' . $order->get_order_key(),


### PR DESCRIPTION
### Why
The plugins that manage the multi-currency support on woocommerce are used to update the currency value for the user session.
So when a user updates his currency the value of `get_woocommerce_currency` changes.

The method `stem.liana.drcr.library._utils.validate_drcr_params` on the line `26` we check if the currency that we send is the same as the value of the `card.currency`, and if it doesn't match and we have an error `'Rule matching query cannot be found.'` 

Based on all this, for example, when the default store currency is USD, and the store supports `USD/EUR`. 
A client that chooses the currency to `EUR` can't redeem their points because the currency won't match, and the order can't be placed